### PR TITLE
Add JSON formatting and include CVE Description in JSON output

### DIFF
--- a/scripts/check-missing-templates.sh
+++ b/scripts/check-missing-templates.sh
@@ -6,7 +6,7 @@
 #
 # @author: edoardottt, https://www.edoardoottavianelli.it/
 #
-# usage: ./check-missing-templates.sh {year} {output-file} - {} means optional
+# usage: ./check-missing-templates.sh {year} {output-file} {output-file json format} - {} means optional
 #
 # usage:
 # $> ./check-missing-templates.sh 2017 missing-templates-2017.txt (starting from 2017 until now)
@@ -19,7 +19,7 @@ echo -e "\033[1;35m===== CHECK MISSING NUCLEI TEMPLATES =====\033[0m"
 echo ""
 echo -e "[ \033[32mSTATUS\033[0m ] Scan started."
 echo ""
-usage="usage: ./check-missing-templates.sh {year} {output-file} - {} means optional."
+usage="usage: ./check-missing-templates.sh {year} {output-file} {output-file json format} - {} means optional."
 
 ######################################
 # 	global vars
@@ -69,6 +69,7 @@ if [[ -z "$1" ]];
 then
 	startyear="1999"
 	outputfile=""
+	outputjsonfile=""
 else
 	if [[ "$1" =~ $re ]] ; then
 		if [[ "$1" -lt "1998" || "$1" -ge "2024" ]];
@@ -88,9 +89,19 @@ if ! [[ -z "$2" ]]; then
 	outputfile="$2"
 fi
 
+if ! [[ -z "$3" ]]; then
+	outputjsonfile="$3"
+fi
+
 if ! [[ -z "$outputfile" ]]; then
 	rm -rf "$outputfile"
 	touch "$outputfile"
+fi
+
+if ! [[ -z "$outputjsonfile" ]]; then
+	rm -rf "$outputjsonfile"
+	touch "$outputjsonfile"
+    echo "[" > "$outputjsonfile"
 fi
 
 # number of CVEs to be analyzed:
@@ -99,6 +110,7 @@ cves=$(find $HOME/github/cve -type f -name "*CVE*" | wc -l)
 echo "===================================="
 echo "> Start year: $startyear"
 echo "> Output file: $outputfile"
+echo "> Output file JSON: $outputjsonfile"
 echo "> CVEs: $cves"
 echo "===================================="
 echo ""
@@ -180,6 +192,29 @@ for dir in $(ls $CVE_REPO) ; do
   								echo -n "[ $missing_to_print ] " >> $outputfile
   								echo "https://github.com/trickest/cve/blob/main/$year/$cve_file" >> $outputfile
   							fi
+
+							if [[ ! -z "$outputjsonfile" ]]; then
+								description=$(cat ${CVE_REPO}/${year}/${cve_file} | \
+									sed -n '/### Description/,/### POC/p' | \
+									sed -e '/### Description/,+1d; /### POC/d' | \
+									sed '$ d' | \
+									sed 's/\\/\\\\/g' | \
+									tr -s '\n\r ' ' ')
+
+								jsondata=`jq \
+									-n \
+									--arg cve "${cve}" \
+									--arg category "${missing_to_print}" \
+									--arg url "https://github.com/trickest/cve/blob/main/$year/$cve_file" \
+									--arg description "${description}" \
+									'{
+										"cve": $cve,
+										"category": $category,
+										"url": $url,
+										"description": $description,
+									}'`
+								echo -e "${jsondata}," >> $outputjsonfile
+							fi
 						fi
   					done
   				fi
@@ -187,3 +222,12 @@ for dir in $(ls $CVE_REPO) ; do
   		done
   	fi
 done
+
+if [[ ! -z "$outputjsonfile" ]]; then
+    # Check if the last line contains a comma
+    if tail -n 1 "$outputjsonfile" | grep -q ','; then
+        # If it does, remove the last character from the last line
+        sed -i '$s/.$//' "$outputjsonfile"
+    fi
+    echo "]" >> "$outputjsonfile"
+fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -10,7 +10,7 @@ cd $ROOTPATH
 git pull
 
 # update CVEs
-bash $ROOTPATH/scripts/check-missing-templates.sh $ROOTPATH/data/all.txt
+bash $ROOTPATH/scripts/check-missing-templates.sh $ROOTPATH/data/all.txt $ROOTPATH/data/all.json
 
 # Generate new README.md with updated stats
 


### PR DESCRIPTION
Fixes issues: #4 and #8

**Is your feature request related to a problem? Please describe.**
When looking for nuclei templates to write, it is frustrating to scour through the list to read the description of each CVE to identify if there's value in writing a nuclei template.

**Changes:**
- Add new argument to for the JSON output in `scripts/check-missing-templates.sh`
- Update `scripts/update.sh` to include a `all.json` for the JSON output.

You will need to install `jq` for the edited script to work.
- For MacOS: `brew install jq`
- For Linux: `apt install jq` or `yum install jq`

Let me know if you want any changes and if the script works for you.